### PR TITLE
Add UIX QM button to download portal world

### DIFF
--- a/WorldPredownload/Constants.cs
+++ b/WorldPredownload/Constants.cs
@@ -35,6 +35,7 @@ namespace WorldPredownload
         public const string SUCCESS_LEFT_BTN_TEXT = "Go to World Page";
         public const string SUCCESS_RIGHT_BTN_TEXT = "Dismiss";
         public const string SUCCESS_LEFT_BTN_TEXT_F = "Go to Friend Page";
+        public const string SUCCESS_LEFT_BTN_TEXT_P = "Join portal instance";
         public const float FRIEND_PANEL_YPOS = -350f;
         public const float FRIEND_PANEL_YSCALE = 1.1f;
         public const float SOCIAL_PANEL_YPOS = 384f;

--- a/WorldPredownload/DownloadManager/DownloadComplete.cs
+++ b/WorldPredownload/DownloadManager/DownloadComplete.cs
@@ -110,6 +110,19 @@ namespace WorldPredownload.DownloadManager
                     }
 
                     break;
+
+                case DownloadType.Portal:
+                    if (!ModSettings.autoFollowPortals)
+                    {
+                        if (ModSettings.showPopupsOnComplete)
+                            DisplayPortalPopup();
+                    }
+                    else
+                    {
+                        Utilities.GoToWorld(DownloadInfo.ApiWorld, DownloadInfo.InstanceIDTags, false);
+                    }
+
+                    break;
             }
         }
     }

--- a/WorldPredownload/DownloadManager/DownloadInfo.cs
+++ b/WorldPredownload/DownloadManager/DownloadInfo.cs
@@ -12,15 +12,17 @@ namespace WorldPredownload.DownloadManager
             DownloadType downloadType,
             PageUserInfo pageUserInfo = null!,
             PageWorldInfo pageWorldInfo = null!,
-            Notification notification = null!)
+            Notification notification = null!,
+            PortalInternal portal = null!)
         {
-            this.ApiWorld = apiWorld;
-            this.InstanceIDTags = instanceIDTags;
-            this.DownloadType = downloadType;
-            this.PageUserInfo = pageUserInfo;
+            ApiWorld = apiWorld;
+            InstanceIDTags = instanceIDTags;
+            DownloadType = downloadType;
+            PageUserInfo = pageUserInfo;
             if (pageUserInfo != null) APIUser = pageUserInfo.field_Private_APIUser_0;
-            this.PageWorldInfo = pageWorldInfo;
-            this.Notification = notification;
+            PageWorldInfo = pageWorldInfo;
+            Notification = notification;
+            Portal = portal;
         }
 
         public ApiWorld ApiWorld { get; set; }
@@ -31,6 +33,7 @@ namespace WorldPredownload.DownloadManager
         public APIUser? APIUser { get; set; }
         public PageWorldInfo? PageWorldInfo { get; set; }
         public Notification? Notification { get; set; }
+        public PortalInternal? Portal { get; set; }
 
         public static DownloadInfo CreateInviteDownloadInfo(
             ApiWorld apiWorld,
@@ -40,7 +43,7 @@ namespace WorldPredownload.DownloadManager
         {
             return new(apiWorld, instanceIDTags, downloadType, null!, null!, notification);
         }
-        
+
         public static DownloadInfo CreateWorldPageDownloadInfo(
             ApiWorld apiWorld,
             string instanceIDTags,
@@ -57,6 +60,15 @@ namespace WorldPredownload.DownloadManager
             PageUserInfo pageUserInfo)
         {
             return new(apiWorld, instanceIDTags, downloadType, pageUserInfo);
+        }
+
+        public static DownloadInfo CreatePortalDownloadInfo(
+            ApiWorld apiWorld,
+            string instanceIDTags,
+            DownloadType downloadType,
+            PortalInternal portal)
+        {
+            return new(apiWorld, instanceIDTags, downloadType, null!, null!, null!, portal);
         }
     }
 }

--- a/WorldPredownload/DownloadManager/DownloadType.cs
+++ b/WorldPredownload/DownloadManager/DownloadType.cs
@@ -4,6 +4,7 @@
     {
         World,
         Friend,
-        Invite
+        Invite,
+        Portal
     }
 }

--- a/WorldPredownload/DownloadManager/WorldDownloadManager.cs
+++ b/WorldPredownload/DownloadManager/WorldDownloadManager.cs
@@ -110,6 +110,27 @@ namespace WorldPredownload.DownloadManager
             );
         }
 
+        private static void DisplayPortalPopup()
+        {
+            Utilities.ShowOptionPopup(
+                Constants.SUCCESS_TITLE,
+                Constants.SUCCESS_MSG,
+                Constants.SUCCESS_LEFT_BTN_TEXT_P,
+                new Action(delegate
+                {
+                    Utilities.HideCurrentPopup();
+                    Utilities.GoToWorld(DownloadInfo.ApiWorld, DownloadInfo.InstanceIDTags, false);
+                    ClearDownload();
+                }),
+                Constants.SUCCESS_RIGHT_BTN_TEXT,
+                new Action(delegate
+                {
+                    Utilities.HideCurrentPopup();
+                    ClearDownload();
+                })
+            );
+        }
+
         private static void DownloadWorld(ApiWorld apiWorld)
         {
             if (!Downloading)
@@ -182,7 +203,7 @@ namespace WorldPredownload.DownloadManager
             #if DEBUG
             MelonLogger.Msg($"AssetUrl: {apiWorld.assetUrl}");
             #endif
-            
+
             webClient.DownloadFileAsync(new Uri(apiWorld.assetUrl), fileName);
         }
     }

--- a/WorldPredownload/Main.cs
+++ b/WorldPredownload/Main.cs
@@ -3,7 +3,7 @@ using ModJsonGenerator;
 using UIExpansionKit.API;
 using WorldPredownload.UI;
 
-[assembly: MelonInfo(typeof(WorldPredownload.WorldPredownload), "WorldPredownload", "1.6.7", "gompo", "https://github.com/gompoc/VRChatMods/releases/")]
+[assembly: MelonInfo(typeof(WorldPredownload.WorldPredownload), "WorldPredownload", "1.6.8", "gompo", "https://github.com/gompoc/VRChatMods/releases/")]
 [assembly: MelonGame("VRChat", "VRChat")]
 [assembly: ModJsonInfo(
         141,
@@ -39,7 +39,6 @@ namespace WorldPredownload
             ExpansionKitApi.OnUiManagerInit += UiManagerInit;
         }
 
-
         private void UiManagerInit()
         {
             if (string.IsNullOrEmpty(ID)) return;
@@ -48,6 +47,7 @@ namespace WorldPredownload
             WorldButton.Setup();
             //WorldDownloadStatus.Setup();
             HudIcon.Setup();
+            PortalButton.Setup();
         }
 
         public override void OnPreferencesLoaded()

--- a/WorldPredownload/ModSettings.cs
+++ b/WorldPredownload/ModSettings.cs
@@ -12,6 +12,7 @@ namespace WorldPredownload
         internal static MelonPreferences_Entry<bool> AutoFollowInvites,
             AutoFollowFriends,
             AutoFollowWorlds,
+            AutoFollowPortals,
             ShowStatusOnQM,
             HideQMStatusWhenInActive,
             ShowHudMessages,
@@ -24,6 +25,7 @@ namespace WorldPredownload
         public static bool autoFollowInvites { get; private set; }
         public static bool autoFollowFriends { get; private set; }
         public static bool autoFollowWorlds { get; private set; }
+        public static bool autoFollowPortals { get; private set; } = false;
         public static bool showStatusOnQM { get; private set; } = true;
         public static bool hideQMStatusWhenInActive { get; private set; }
         public static bool showHudMessages { get; private set; } = true;
@@ -45,13 +47,14 @@ namespace WorldPredownload
             AutoFollowInvites = category.CreateEntry("AutoFollowInvites", autoFollowInvites, "Auto Follow Invite Predownloads");
             AutoFollowWorlds = category.CreateEntry("AutoFollowWorlds", autoFollowWorlds, "Auto Join World Predownloads");
             AutoFollowFriends = category.CreateEntry("AutoFollowFriends", autoFollowFriends, "Auto Join Friend Predownloads");
+            AutoFollowPortals = category.CreateEntry("AutoFollowPortals", autoFollowPortals, "Auto Join Portal Predownloads");
             ShowStatusOnQM = category.CreateEntry("ShowStatusOnQM", showStatusOnQM, "Display download status on QM");
             HideQMStatusWhenInActive = category.CreateEntry("HideQMStatusWhenInActive", hideQMStatusWhenInActive, "Hide status on QM when not downloading");
             ShowStatusOnHud = category.CreateEntry("ShowStatusOnHud", showStatusOnHud, "Display download status on HUD");
             ShowHudMessages = category.CreateEntry("ShowHudMessages", showHudMessages, "Show Hud Messages");
             ShowPopupsOnComplete = category.CreateEntry("ShowPopupsOnComplete", showPopupsOnComplete, "Show Popup On Complete");
             DownloadUserAgent = category.CreateEntry("DownloadUserAgent", downloadUserAgent, null, null, true);
-            
+
             //CVRStyle = category.CreateEntry("OverrideVRChatJoinWorldButtons", cvrStyle, "Override VRChat Join Buttons (CVR Style  & Requires Restart to Apply)") as MelonPreferences_Entry<bool>;
             if (AdvancedInvites)
                 TryUseAdvancedInvitePopup = category.CreateEntry("UseAdvancedInvitesPopup", tryUseAdvancedInvitePopup, "Accept invites using AdvancedInvites popup");

--- a/WorldPredownload/UI/PortalButton.cs
+++ b/WorldPredownload/UI/PortalButton.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using UnityEngine;
+using VRC;
+using UIExpansionKit.API;
+using WorldPredownload.DownloadManager;
+using WorldPredownload.Cache;
+using WorldPredownload.Helpers;
+
+namespace WorldPredownload.UI
+{
+    public class PortalButton
+    {
+        private static Player LocalPlayer => PlayerManager.field_Private_Static_PlayerManager_0.field_Private_Player_0;
+
+        private static void PreDownloadPortal()
+        {
+            // Get all portals
+            var portals = Resources.FindObjectsOfTypeAll<PortalInternal>();
+
+            // Check if there are any portals
+            if (portals.Length == 0)
+            {
+                Utilities.ShowDismissPopup(
+                    "No portals found!",
+                    "No portals found in this world to download from.",
+                    Constants.ERROR_BTN_TEXT,
+                    new Action(delegate
+                    {
+                        Utilities.HideCurrentPopup();
+                    })
+                );
+                return;
+            }
+
+            // Get the nearest portal
+            var nearestPortal = portals.OrderBy(p => Vector3.Distance(p.transform.position, LocalPlayer.transform.position)).FirstOrDefault();
+
+            // Get the target world of the portal
+            var targetWorld = nearestPortal.field_Private_ApiWorld_0;
+
+            // Check if the world is already downloaded
+            if (!WorldDownloadManager.Downloading && !CacheManager.HasDownloadedWorld(targetWorld.assetUrl))
+            {
+                // Pre-download the world
+                WorldDownloadManager.ProcessDownload(
+                    DownloadInfo.CreatePortalDownloadInfo(
+                        targetWorld,
+                        nearestPortal.field_Private_String_4,
+                        DownloadType.Portal,
+                        nearestPortal
+                    )
+                );
+            }
+            else
+            {
+                Utilities.ShowDismissPopup(
+                    "Portal world already downloaded",
+                    "You can't pre-download a world that is already downloaded.",
+                    Constants.ERROR_BTN_TEXT,
+                    new Action(delegate
+                    {
+                        Utilities.HideCurrentPopup();
+                    })
+                );
+            }
+        }
+
+        public static void Setup()
+        {
+            ExpansionKitApi.GetExpandedMenu(ExpandedMenu.QuickMenu).AddSimpleButton("Download world of closest portal", PreDownloadPortal);
+        }
+    }
+}

--- a/WorldPredownload/WorldPredownload.csproj
+++ b/WorldPredownload/WorldPredownload.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <VrcReferences>true</VrcReferences>
-        <Version>1.6.7.0</Version>
+        <Version>1.6.8.0</Version>
         <LangVersion>9</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>annotations</Nullable>


### PR DESCRIPTION
Works similar to existing options
Once downloaded shows a popup with the option to join the instance of the portal you downloaded the world from.
Will show a warning popup if the world is already downloaded/downloading or if there are no portals placed down in the current world to download from.
Includes a setting similar to the existing methods to auto-follow the portal instance once download is complete.